### PR TITLE
Support load balanced Grafana instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Currently, the project is comprised of the following products:
 - **himond**
   - Cool, little system metric emmitter for StatsD, written in C++
   - https://github.com/bartoffw/himond
+- **Memcached**
+  - In-memory key-value store; using this pup to share Grafana session with multiple Grafana container/services
+  - https://memcached.org/
+  - https://hub.docker.com/_/memcached/
+- **HAProxy**
+  - Lightweight TCP/HTTP load balancer; handy to scale Grafana behind it and test session persistence
+  - http://www.haproxy.org/
+  - https://hub.docker.com/r/dockercloud/haproxy/
+  - https://github.com/docker/dockercloud-haproxy
 
 ### Requirements ###
 - Docker 1.13 (tested on Docker 1.13.1)
@@ -52,6 +61,6 @@ What license?!
 
 ### In the future ###
 - [ ] I'd like to add a Docker Swarm equivalent (Stack)
-- [ ] I'd like to add support for session data to be stored on MemcacheD (more Dockers!)
+- [x] I'd like to add support for session data to be stored on MemcacheD (more Dockers!)
 - [ ] I'd like to ship more backend data sources & test emitters for each
 - [ ] Include better, templated dashboards to demo Grafana and the underlying TSDBs

--- a/bin/start-demo.sh
+++ b/bin/start-demo.sh
@@ -14,15 +14,21 @@ then
   docker create -v /dbdata --name pgdata_grafana postgres:alpine;
 fi
 
+# Create a container volume to persist Graphite data
+if [[ -z $(docker ps -a |grep graphite_data |awk '{print $1}') ]]
+then
+  docker create -v /opt/graphite/storage --name graphite_data hopsoft/graphite-statsd;
+fi
+
 # Tear down pre-existing stacks
 docker-compose -f ../docker-compose.yml down;
 
 # Compose up our stack!
-docker-compose -f ../docker-compose.yml up &
+docker-compose -f ../docker-compose.yml up --scale grafana=2 &
 
 # Wait 10 seconds
 sleep 10;
 
 # Launch himond and start sending metrics to Graphite/StatsD
-sudo ./himond localhost 8125 wlp3s0;
+sudo ./himond localhost 8125 wlp59s0 &
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,16 @@
 version: '2.1'
+
 services:
+  proxy:
+    privileged: true
+    image: dockercloud/haproxy:latest
+    ports:
+      - 8080:80
+    links:
+      - grafana
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+
   db:
     image: postgres:alpine
     volumes:
@@ -8,7 +19,7 @@ services:
       - 5432:5432
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
-      interval: 60s
+      interval: 10s
       timeout: 5s
       retries: 5
     environment:
@@ -21,12 +32,12 @@ services:
       db:
         condition: service_healthy
     image: grafana/grafana
-    ports:
-      - 3000:3000
+    expose:
+      - 3000
     environment:
       GF_SECURITY_ADMIN_PASSWORD: password
       GF_SECURITY_ADMIN_USER: admin
-      GF_SECURITY_LOGIN_REMEMBER_DAYS:
+      # GF_SECURITY_LOGIN_REMEMBER_DAYS:
       GF_USERS_ALLOW_ORG_CREATE: "false"
       GF_SERVER_HTTP_PORT: 3000
       # GF_SERVER_HTTP_ADDR: localhost
@@ -46,7 +57,7 @@ services:
   graphite:
     image: hopsoft/graphite-statsd
     ports:
-      - 80:80
+      - 8081:80
       - 2003-2004:2003-2004
       - 2023-2024:2023-2024
       - 8125:8125/udp
@@ -54,8 +65,9 @@ services:
 
   memcached:
     image: memcached:alpine
-    ports:
-      - 11211:11211
+    expose:
+      - 11211
 
 volumes:
   pgdata_grafana:
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       GF_USERS_ALLOW_ORG_CREATE: "false"
       GF_SERVER_HTTP_PORT: 3000
       # GF_SERVER_HTTP_ADDR: localhost
+      GF_SERVER_ROUTER_LOGGING: "true"
       GF_DATABASE_TYPE: postgres
       GF_DATABASE_HOST: db
       GF_DATABASE_NAME: grafana

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,11 @@ services:
       GF_DATABASE_PASSWORD: password
       GF_DATABASE_MAX_IDLE_CONN: 20
       GF_DATABASE_MAX_OPEN_CONN: 20
+      GF_SESSION_PROVIDER: memcache
+      GF_SESSION_PROVIDER_CONFIG: memcached:11211
+      # GF_SESSION_COOKIE_NAME: 
+      # GF_SESSION_COOKIE_SECURE:
+      # GF_SESSION_SESSION_LIFE_TIME:
 
   graphite:
     image: hopsoft/graphite-statsd
@@ -46,6 +51,11 @@ services:
       - 2023-2024:2023-2024
       - 8125:8125/udp
       - 8126:8126
+
+  memcached:
+    image: memcached:alpine
+    ports:
+      - 11211:11211
 
 volumes:
   pgdata_grafana:


### PR DESCRIPTION
This should meet the requirements of #2 
- [x] Add Memcached container / service
- [x] Configure Grafana service to use Memcached
- [x] Add HAProxy to load-balance multiple Grafana instances
- [x] Add data persistence support for Graphite